### PR TITLE
mmu: ALIGN_DOWN tail not addr

### DIFF
--- a/drm/nouveau/nvkm/subdev/mmu/vmm.c
+++ b/drm/nouveau/nvkm/subdev/mmu/vmm.c
@@ -1354,7 +1354,7 @@ nvkm_vmm_get_locked(struct nvkm_vmm *vmm, bool getref, bool mapref, bool sparse,
 
 		tail = this->addr + this->size;
 		if (vmm->func->page_block && next && next->page != p)
-			tail = ALIGN_DOWN(addr, vmm->func->page_block);
+			tail = ALIGN_DOWN(tail, vmm->func->page_block);
 
 		if (addr <= tail && tail - addr >= size) {
 			rb_erase(&this->tree, &vmm->free);


### PR DESCRIPTION
Corrects copy/pasta error from 7110c89bb8852ff8b0f88ce05b332b3fe22bd11e
Fixes screen corruption and X lock-ups observed on NV98.