### PR TITLE
Fix failed include paths

### DIFF
--- a/drm/nouveau/Kbuild
+++ b/drm/nouveau/Kbuild
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: MIT
-ccflags-y += -I $(srctree)/$(src)/include
-ccflags-y += -I $(srctree)/$(src)/include/nvkm
-ccflags-y += -I $(srctree)/$(src)/nvkm
-ccflags-y += -I $(srctree)/$(src)
+ccflags-y += -I$(src)/include
+ccflags-y += -I$(src)/include/nvkm
+ccflags-y += -I$(src)/nvkm
+ccflags-y += -I$(src)
 
 # NVKM - HW resource manager
 #- code also used by various userspace tools/tests


### PR DESCRIPTION
This change was necessary before I was able to successfully compile.

According to the kbuild documentation, `-I` elements in `ccflags-y` do not support using spaces between the `-I` and the path. Furthermore, the variable `$(src)` contains the absolute path to the directory holding the current `Kbuild` file, `$(srctree)` is not mentioned and seems unnecessary.

See https://www.kernel.org/doc/html/latest/kbuild/modules.html#single-subdirectory (sections "4.2 Single Subdirectory" and "4.3 Several Subdirectories").